### PR TITLE
RNMT-2106 - Fix concurrency issues in Barcode Scanner plugin

### DIFF
--- a/android/ZBarScannerActivity.java
+++ b/android/ZBarScannerActivity.java
@@ -403,15 +403,20 @@ implements SurfaceHolder.Callback {
             barcode.setData(data);
 
             if (scanner.scanImage(barcode) != 0) {
-                String qrValue = "";
+                Symbol symbol = null;
 
                 SymbolSet syms = scanner.getResults();
                 for (Symbol sym : syms) {
-                    qrValue = sym.getData();
-
                     // Return 1st found QR code value to the calling Activity.
+                    if(sym.getType() > Symbol.PARTIAL){
+                        symbol = sym;
+                        break;
+                    }
+                }
+
+                if(symbol != null){
                     Intent result = new Intent ();
-                    result.putExtra(EXTRA_QRVALUE, qrValue);
+                    result.putExtra(EXTRA_QRVALUE, symbol.getData());
                     setResult(Activity.RESULT_OK, result);
                     finish();
                 }

--- a/android/ZBarScannerActivity.java
+++ b/android/ZBarScannerActivity.java
@@ -302,6 +302,8 @@ implements SurfaceHolder.Callback {
     }
     public void onConfigurationChanged(Configuration newConfig)
     {
+        if (camera == null) return;
+
         super.onConfigurationChanged(newConfig);
         int rotation = getWindowManager().getDefaultDisplay().getRotation();
         switch(rotation)
@@ -334,7 +336,9 @@ implements SurfaceHolder.Callback {
     }
 
     public void toggleFlash(View view) {
-		camera.startPreview();
+        if(camera == null) return;
+
+        camera.startPreview();
         android.hardware.Camera.Parameters camParams = camera.getParameters();
         //If the flash is set to off
         try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-cszbar",
-  "version": "1.3.3-OS2",
+  "version": "1.3.3-OS3",
   "description": "Plugin to integrate with the ZBar barcode scanning library.",
   "cordova": {
     "id": "cordova-plugin-cszbar",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
-        id="cordova-plugin-cszbar" version="1.3.3-OS2">
+        id="cordova-plugin-cszbar" version="1.3.3-OS3">
 
     <engines>
         <engine name="cordova" version=">=3.0.0" />


### PR DESCRIPTION
Some concurrency issues were reported on Android apps that were causing apps crashes.
Whenever a barcode value is retrieved form a scanned image, it automatically dismisses the Scanner Activity and releases the camera object, without any protection against concurrent accesses to it. Thus, any async access to the camera object will crash the app.

With this fix, the plugin will iterate the scanner result set and get the first symbol that is valid. If a symbol is found, then its value is returned to the activity. 

Issue: https://outsystemsrd.atlassian.net/browse/RNMT-2106