### PR TITLE
RNMT-2198 Allow a custom message for the Camera Usage Description

### DIFF
--- a/outsystems.json
+++ b/outsystems.json
@@ -1,0 +1,11 @@
+{
+    "plugin": {
+        "url": "https://github.com/OutSystems/csZBar.git#v1.3.3-OS4",
+        "variables": [
+            {
+                "name": "CAMERA_USAGE_DESCRIPTION",
+                "value": "We access your camera to scan barcodes."
+            }
+        ]
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-cszbar",
-  "version": "1.3.3-OS3",
+  "version": "1.3.3-OS4",
   "description": "Plugin to integrate with the ZBar barcode scanning library.",
   "cordova": {
     "id": "cordova-plugin-cszbar",

--- a/plugin.xml
+++ b/plugin.xml
@@ -73,8 +73,9 @@
         </config-file>
 
         <!-- Declare Camera Usage for iOS10+ -->
+        <preference name="CAMERA_USAGE_DESCRIPTION" default="We access your camera to scan barcodes." />
         <config-file target="*-Info.plist" parent="NSCameraUsageDescription">
-            <string>For Barcode Scanning</string>
+            <string>$CAMERA_USAGE_DESCRIPTION</string>
         </config-file>
 
         <framework src="AVFoundation.framework" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
-        id="cordova-plugin-cszbar" version="1.3.3-OS3">
+        id="cordova-plugin-cszbar" version="1.3.3-OS4">
 
     <engines>
         <engine name="cordova" version=">=3.0.0" />


### PR DESCRIPTION
Apple is rejecting apps with the Barcode Plugin by stating that the current Camera Usage Description message it's not clear.

For more details, please check the issue [RNMT-2193](https://outsystemsrd.atlassian.net/browse/RNMT-2193)