### PR TITLE
Fixes typo in plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -54,7 +54,7 @@
         <source-file src="android/libs/armeabi-v7a/libiconv.so" target-dir="libs/armeabi-v7a" />
         <source-file src="android/libs/armeabi-v7a/libzbarjni.so" target-dir="libs/armeabi-v7a" />
         <source-file src="android/libs/arm64-v8a/libiconv.so" target-dir="libs/arm64-v8a" />
-        <source-file src="android/libs/arm64-v8a/libzbarjni.so" target-dir="libs/arm64-v8a" />s
+        <source-file src="android/libs/arm64-v8a/libzbarjni.so" target-dir="libs/arm64-v8a" />
         <source-file src="android/libs/x86/libiconv.so" target-dir="libs/x86" />
         <source-file src="android/libs/x86/libzbarjni.so" target-dir="libs/x86" />
         <source-file src="android/res/drawable/camera_flash.png" target-dir="res/drawable"/>


### PR DESCRIPTION
Fixes typo in` plugin.xml` file: Removes leftover character after `<source-file>` tag