### PR TITLE
RNMT-3266 Dynamically select dependency version

### DIFF
--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -1,0 +1,13 @@
+String getVersion() {
+  def compileSdkVersion = Integer.parseInt(project.android.compileSdkVersion.split("-")[1])
+  return compileSdkVersion >= 28 ? "28.0.0" : "23.1.0" 
+}
+
+// Defer the definition of the dependencies to the end
+// of the "configuration" phase from the app build.gradle file
+// so that we can inquire the proper compile sdk version being used.
+cdvPluginPostBuildExtras.push({
+  dependencies {
+    implementation "com.android.support:support-v4:${getVersion()}"
+  }
+})

--- a/plugin.xml
+++ b/plugin.xml
@@ -43,7 +43,7 @@
             <color name="csZbarScannerTextBackground">#88000000</color>
             <color name="csZbarScannerBackground">#000000</color>
         </config-file>
-        <framework src="com.android.support:support-v4:28.0.0" />
+        <framework src="libs/android/build.gradle" custom="true" type="gradleReference" />
         <resource-file src="android/res/layout/cszbarscanner.xml" target="res/layout/cszbarscanner.xml" />
         <source-file src="android/ZBarcodeFormat.java" target-dir="src/org/cloudsky/cordovaPlugins" />
         <source-file src="android/ZBar.java" target-dir="src/org/cloudsky/cordovaPlugins" />


### PR DESCRIPTION
This PR adds the ability for the plugin to pick and choose, in build time, which is the appropriate support library version that must be used depending on the compileSdkVersion (and indirectly the MABS version) in use.

References https://outsystemsrd.atlassian.net/browse/RNMT-3266