### PR TITLE
RNMT-4083 Remove UIWebView references

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This plugin integrates with the [ZBar](http://zbar.sourceforge.net/) library,
 exposing a JavaScript interface for scanning barcodes (QR, 2D, etc).
 In this fork a button has been added to turn off and on device flash. In addition the plugin can now handle the device orientation change.
 
+For iOS platform, the plugin integrates with an updated version of the ZBar library, that can be found [here](https://github.com/OutSystems/zbar/tree/outsystems/iphone).
+
 ## Installation
 
     cordova plugin add cordova-plugin-cszbar

--- a/ios/ZBarSDK/ZBarHelpController.h
+++ b/ios/ZBarSDK/ZBarHelpController.h
@@ -22,6 +22,7 @@
 //------------------------------------------------------------------------
 
 #import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
 
 @class ZBarHelpController;
 
@@ -36,11 +37,12 @@
 // failure dialog w/a few useful tips
 
 @interface ZBarHelpController : UIViewController
-                              < UIWebViewDelegate,
+                              < WKNavigationDelegate,
                                 UIAlertViewDelegate >
 {
     NSString *reason;
     id delegate;
+    WKWebView *webView;
     UIToolbar *toolbar;
     UIBarButtonItem *doneBtn, *backBtn, *space;
     NSURL *linkURL;

--- a/ios/ZBarSDK/ZBarHelpController.h
+++ b/ios/ZBarSDK/ZBarHelpController.h
@@ -41,7 +41,6 @@
 {
     NSString *reason;
     id delegate;
-    UIWebView *webView;
     UIToolbar *toolbar;
     UIBarButtonItem *doneBtn, *backBtn, *space;
     NSURL *linkURL;


### PR DESCRIPTION
This PR removes the references to UIWebView in the plugin. The lib used by iOS platform can be found [here](https://github.com/mchehab/zbar/tree/master/iphone). The lib was generated in xcode 10 (to have backwards compatibility), in Release mode, for simulator and real device, which were converted in a "fat" library using `lipo` command.

The test plan was ran successfully, with the expected resutls, for iOS 11.4 and 13.4, in both O10 and O11, MABS 5.2 and 6.1.

References https://outsystemsrd.atlassian.net/browse/RNMT-4083