### PR TITLE
RMET-527 - iPad dismiss modal ImagePicker clicking outside issue fix

### DIFF
--- a/ios/CsZBar.m
+++ b/ios/CsZBar.m
@@ -8,6 +8,7 @@
 @property bool scanInProgress;
 @property NSString *scanCallbackId;
 @property AlmaZBarReaderViewController *scanReader;
+@property (strong, nonatomic) UITapGestureRecognizer *tapOutsideRecognizer;
 
 @end
 
@@ -100,7 +101,7 @@
 
             self.scanReader.cameraOverlayView = polygonView;
         }
-
+        [self.viewController.view.window addGestureRecognizer:self.tapBehindGesture];
         [self.viewController presentViewController:self.scanReader animated:YES completion:nil];
     }
 }
@@ -168,6 +169,29 @@
                                 resultWithStatus: CDVCommandStatus_ERROR
                                 messageAsString: @"Failed"]];
     }];
+}
+
+- (UITapGestureRecognizer*)tapBehindGesture
+{
+    if (_tapOutsideRecognizer == nil)
+    {
+        _tapOutsideRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tapBehindRecognized)];
+        _tapOutsideRecognizer.numberOfTapsRequired = 1;
+        _tapOutsideRecognizer.cancelsTouchesInView = NO;
+        _tapOutsideRecognizer.delegate = self;
+    }
+
+    return _tapOutsideRecognizer;
+}
+
+-(void)tapBehindRecognized {
+    [self.viewController.view.window removeGestureRecognizer:self.tapBehindGesture];
+    self.scanInProgress = NO;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+    return YES;
 }
 
 @end


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added a UIGestureRecognizer to detect clicks outside the UIImagePickerController

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

Closes: 
https://outsystemsrd.atlassian.net/browse/RMET-527

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
- [ ] Documentation has been updated accordingly
