### PR TITLE
Allow Google X64 to be passed

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -57,6 +57,8 @@
         <source-file src="android/libs/arm64-v8a/libzbarjni.so" target-dir="libs/arm64-v8a" />
         <source-file src="android/libs/x86/libiconv.so" target-dir="libs/x86" />
         <source-file src="android/libs/x86/libzbarjni.so" target-dir="libs/x86" />
+        <source-file src="android/libs/x86_64/libiconv.so" target-dir="libs/x86_64" />
+        <source-file src="android/libs/x86_64/libzbarjni.so" target-dir="libs/x86_64" />
         <source-file src="android/res/drawable/camera_flash.png" target-dir="res/drawable"/>
         <source-file src="android/res/drawable/camera_flash.png" target-dir="res/drawable-hdpi"/>
         <source-file src="android/res/drawable/camera_flash.png" target-dir="res/drawable-ldpi"/>


### PR DESCRIPTION
Google has modified their X64 check and will refuse to install Apps which bundles csZBar, if they do not contain the x86_64 libraries.
As they are already contained in this repository but not transfered to the build script, all this does is adding them in plugin.xml.
With that Google Play accepts the upload again